### PR TITLE
Check for nsmDialog in component before accessing length

### DIFF
--- a/src/ngx-smart-modal/src/components/ngx-smart-modal.component.ts
+++ b/src/ngx-smart-modal/src/components/ngx-smart-modal.component.ts
@@ -306,7 +306,7 @@ export class NgxSmartModalComponent implements OnInit, OnDestroy, AfterViewInit 
    */
   @HostListener('window:resize')
   public targetPlacement(): boolean | void {
-    if (!this.isBrowser || !this.nsmDialog.length || !this.nsmContent.length || !this.nsmOverlay.length || !this.target) {
+    if (!this.isBrowser || !this.nsmDialog || !this.nsmDialog.length || !this.nsmContent.length || !this.nsmOverlay.length || !this.target) {
       return false;
     }
     const targetElement = this._document.querySelector(this.target);


### PR DESCRIPTION
We sometimes observe this error:

```
TypeError: Cannot read property 'length' of undefined
    at length (webpack:///node_modules/ngx-smart-modal/esm2015/ngx-smart-modal.js:284:47)
    at webpack:///node_modules/ngx-smart-modal/esm2015/ngx-smart-modal.js:346:109
    at ...
```

which we could track back to not checking for `this.nsmDialog` when checking `this.nsmDialog.length` in `NgxSmartModalComponent.targetPlacement`.

I added a simple check to `targetPlacement`.