### PR TITLE
Fixed ability to use @ Input() dynamic content.

### DIFF
--- a/src/app/demo/fake/fake.component.html
+++ b/src/app/demo/fake/fake.component.html
@@ -1,3 +1,4 @@
-<h1>Hello {{ name }}</h1>
-<p>I'm a component !</p>
-<p>Just to say, "Jack" is a template binding value!</p>
+<h1>Hello {{ firstname }} {{ lastname }}</h1>
+<p>I'm a component!</p>
+<p>"Jack" is a template binding value!</p>
+<p *ngIf="lastname">"Frost" is an @Input() value!</p>

--- a/src/app/demo/fake/fake.component.ts
+++ b/src/app/demo/fake/fake.component.ts
@@ -1,3 +1,4 @@
+import { Input } from '@angular/core';
 import { Component, OnInit } from '@angular/core';
 
 @Component({
@@ -6,8 +7,8 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./fake.component.scss']
 })
 export class FakeComponent implements OnInit {
-
-  public name = 'Jack';
+  firstname: string = 'Jack';
+  @Input() lastname: string;
 
   constructor() {
   }

--- a/src/app/demo/main/main.component.html
+++ b/src/app/demo/main/main.component.html
@@ -1,7 +1,7 @@
 <ng-template #tpl>
     <h1>Hello {{ name }}</h1>
-    <p>I'm TemplateRef content !</p>
-    <p>Just to say, "Bobby" is a template binding value!</p>
+    <p>I'm TemplateRef content!</p>
+    <p>"Bobby" is a template binding value!</p>
 </ng-template>
 
 <div class="container">

--- a/src/app/demo/main/main.component.ts
+++ b/src/app/demo/main/main.component.ts
@@ -93,9 +93,14 @@ export class MainComponent implements AfterViewInit {
 
     this.ngxSmartModalService.create('dynamicModal1', 'Hello, I\'m a simple text !').open();
 
-    this.ngxSmartModalService.create('dynamicModal2', FakeComponent, opts).open();
+    this.ngxSmartModalService.create('dynamicModal2', this.tpl, opts).open();
 
-    this.ngxSmartModalService.create('dynamicModal3', this.tpl, opts).open();
+    this.ngxSmartModalService.create('dynamicModal3', FakeComponent, opts).open();
+
+    this.ngxSmartModalService
+      .create('dynamicModal4', FakeComponent, opts)
+      .setData({ lastname: "Frost" })
+      .open();
   }
 
 }

--- a/src/ngx-smart-modal/src/components/ngx-smart-modal.component.ts
+++ b/src/ngx-smart-modal/src/components/ngx-smart-modal.component.ts
@@ -5,6 +5,7 @@ import {
   Component,
   ComponentFactory,
   ComponentFactoryResolver,
+  ComponentRef,
   ElementRef,
   EventEmitter,
   HostListener,
@@ -370,8 +371,17 @@ export class NgxSmartModalComponent implements OnInit, OnDestroy, AfterViewInit 
   private createDynamicContent(changes: QueryList<ViewContainerRef>, factory: ComponentFactory<Component>): void {
     changes.forEach((viewContainerRef: ViewContainerRef) => {
       viewContainerRef.clear();
-      viewContainerRef.createComponent(factory);
+      this.bindDataToComponent(viewContainerRef.createComponent(factory));
       this.markForCheck();
     });
+  }
+
+  /**
+   * Binds the modal data to the instance of the provided ComponentRef
+   */
+  private bindDataToComponent(componentRef: ComponentRef<any>): void {
+    for(const key in this._data) {
+      componentRef.instance[key] = this._data[key];
+    }
   }
 }


### PR DESCRIPTION
- Added the ability to inject the modal data into component @ Input() bindings.
- Modified the relevant demo files to demonstrate the change.

This resolves the issue in #235 where the modal will not display dynamic projected content as data provided through @ Input().

A known limitation of this fix is the inability to directly update the data in the component (after creation) using setData().
```
const modal = this.ngxSmartModalService
      .create('dynamicModal4', FakeComponent, opts)
      .setData({ lastname: "Frost" })
      .open();

modal.setData({ lastname: "Fire" }, true); // Does not update the lastname.
```
You can still directly update data by reference or by using an observable.