### PR TITLE
fixed circular di bug issue 387

### DIFF
--- a/projects/ngx-smart-modal/package.json
+++ b/projects/ngx-smart-modal/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "ngx-smart-modal",
-  "version": "14.0.3",
+  "name": "ngx-smart-modal-wgv",
+  "version": "14.0.4",
   "description": "Smart modal handler to manage modals and data everywhere in Angular apps.",
   "author": "Maxime LAFARIE <maxime.lafarie@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/maximelafarie/ngx-smart-modal.git"
+    "url": "https://github.com/Bierat1337/ngx-smart-modal.git"
   },
   "bugs": {
-    "url": "https://github.com/maximelafarie/ngx-smart-modal/issues"
+    "url": "https://github.com/Bierat1337/ngx-smart-modal/issues"
   },
-  "homepage": "https://github.com/maximelafarie/ngx-smart-modal",
+  "homepage": "https://github.com/Bierat1337/ngx-smart-modal",
   "keywords": [
     "ngx-smart-modal",
     "ngxsm",

--- a/projects/ngx-smart-modal/src/lib/services/ngx-smart-modal.service.ts
+++ b/projects/ngx-smart-modal/src/lib/services/ngx-smart-modal.service.ts
@@ -17,7 +17,6 @@ export class NgxSmartModalService {
     private _appRef: ApplicationRef,
     private _injector: Injector,
     private _modalStack: NgxSmartModalStackService,
-    private applicationRef: ApplicationRef,
     @Inject(DOCUMENT) private _document: any,
     @Inject(PLATFORM_ID) private _platformId: any
   ) {
@@ -426,7 +425,7 @@ export class NgxSmartModalService {
 
     if (content instanceof TemplateRef) {
       const viewRef = content.createEmbeddedView(null as any);
-      this.applicationRef.attachView(viewRef);
+      this._appRef.attachView(viewRef);
       return [viewRef.rootNodes];
     }
 

--- a/projects/ngx-smart-modal/src/lib/services/ngx-smart-modal.service.ts
+++ b/projects/ngx-smart-modal/src/lib/services/ngx-smart-modal.service.ts
@@ -14,7 +14,6 @@ export class NgxSmartModalService {
   private lastElementFocused: any;
 
   constructor(
-    private _appRef: ApplicationRef,
     private _injector: Injector,
     private _modalStack: NgxSmartModalStackService,
     @Inject(DOCUMENT) private _document: any,
@@ -425,7 +424,7 @@ export class NgxSmartModalService {
 
     if (content instanceof TemplateRef) {
       const viewRef = content.createEmbeddedView(null as any);
-      this._appRef.attachView(viewRef);
+      this.appRef.attachView(viewRef);
       return [viewRef.rootNodes];
     }
 
@@ -498,5 +497,13 @@ export class NgxSmartModalService {
     }
 
     this._document.body.removeChild(modal.elementRef.nativeElement);
+  }
+
+  /**
+   * getter function to avoid circular dependency error
+   * @returns ApplicationRef instance
+   * */
+  private get appRef(): ApplicationRef {
+    return this._injector.get(ApplicationRef);
   }
 }


### PR DESCRIPTION
removed appRef in constructor and get it at runtime via getter function to avoid circular di error.

Problem came up in issue:
https://github.com/maximelafarie/ngx-smart-modal/issues/387